### PR TITLE
Update to Vuetify 0.9.2 with some regressions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -401,6 +401,10 @@
         flex: 1 0 40px;
     }
 
+    aside.sidebar .list__tile--active .list__tile__title {
+        color: #00cc00;
+    }
+
     i.fa-2x {
         font-size: 1.5em;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
     <v-app top-navbar left-fixed-sidebar>
         <v-snackbar :timeout="2000" :top="true" :right="true" v-model="noAuth">{{ $t('auth.no') }}</v-snackbar>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="alreadyAuth">{{ $t('auth.already') }}</v-snackbar>
         <header>
             <v-progress-linear id="loadingBar" v-if="loading" :indeterminate="true"></v-progress-linear>
             <v-toolbar class="green">
@@ -129,6 +130,9 @@
             },
             noAuth() {
                 return this.$store.state.noAuthSnackbar
+            },
+            alreadyAuth() {
+                return this.$store.state.alreadyAuthSnackbar
             },
             sidebarItems() {
                 return [

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
     <v-app top-navbar left-fixed-sidebar>
         <v-snackbar :timeout="2000" :top="true" :right="true" v-model="noAuth">{{ $t('auth.no') }}</v-snackbar>
         <v-snackbar :timeout="2000" :top="true" :right="true" v-model="alreadyAuth">{{ $t('auth.already') }}</v-snackbar>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="invalidSession">{{ $t('auth.invalidsession') }}</v-snackbar>
         <header>
             <v-progress-linear id="loadingBar" v-if="loading" :indeterminate="true"></v-progress-linear>
             <v-toolbar class="green">
@@ -162,14 +163,15 @@
             return {
                 lg: '',
                 sidebarOpen: false,
-                sidebarLanguagesOpen: false
+                sidebarLanguagesOpen: false,
+                invalidSession: false
             }
         },
         watch: {
             logout: function(newValue, oldValue) {
                 if (newValue) {
                     this.$store.commit('setLogout', false)
-                    this.$vuetify.toast.create(this.$t('auth.invalidsession'), 'right')
+                    this.invalidSession = true
                     this.$router.push('/' + this.language + '/login')
                 }
             },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <template>
     <v-app top-navbar left-fixed-sidebar>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="noAuth">{{ $t('auth.no') }}</v-snackbar>
         <header>
             <v-progress-linear id="loadingBar" v-if="loading" :indeterminate="true"></v-progress-linear>
             <v-toolbar class="green">
@@ -125,6 +126,9 @@
             },
             toolbarTitleArgs() {
                 return this.$store.state.toolbarTitleArgs
+            },
+            noAuth() {
+                return this.$store.state.noAuthSnackbar
             },
             sidebarItems() {
                 return [

--- a/src/init/translations.js
+++ b/src/init/translations.js
@@ -36,5 +36,6 @@ Vue.use(VeeValidate, {
         es: {
             messages: toLambdas(es.validation)
         }
-    }
+    },
+    errorBagName: 'verrors'
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -68,7 +68,8 @@ export default new Vuex.Store({
         language: '',
         meta: {},
         logout: false,
-        noAuthSnackbar: false
+        noAuthSnackbar: false,
+        alreadyAuthSnackbar: false
     },
     actions: {
         boot ({dispatch, state, commit}) {
@@ -360,6 +361,9 @@ export default new Vuex.Store({
         },
         setNoAuth(state) {
             state.noAuthSnackbar = true
+        },
+        setAlreadyAuth(state) {
+            state.alreadyAuthSnackbar = true
         },
         setLogout(state, newLogout) {
             state.logout = newLogout

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -67,7 +67,8 @@ export default new Vuex.Store({
         version: '',
         language: '',
         meta: {},
-        logout: false
+        logout: false,
+        noAuthSnackbar: false
     },
     actions: {
         boot ({dispatch, state, commit}) {
@@ -356,6 +357,9 @@ export default new Vuex.Store({
         },
         setLoaded (state) {
             state.loading = false
+        },
+        setNoAuth(state) {
+            state.noAuthSnackbar = true
         },
         setLogout(state, newLogout) {
             state.logout = newLogout

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,5 +1,7 @@
 <template>
     <div>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="authsuccess">{{ $t('auth.success') }}</v-snackbar>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="authfail">{{ $t('auth.fail') }}</v-snackbar>
         <v-container>
             <v-row class="mt-5">
                 <v-col md3></v-col>
@@ -7,23 +9,24 @@
                     <v-card class="mp-5">
                         <v-card-text>
                             <h5>{{ $t('user.login.header') }}</h5>
-                            <form @submit.prevent="login" novalidate>
-                                <text-input
+                            <form @submit.prevent="" novalidate>
+                                <v-text-field
                                     :label="$t('user.username')"
                                     :placeholder="$t('user.placeholder.username')"
                                      name="username" v-model="username"
-                                ></text-input>
-                                <text-input
+                                ></v-text-field>
+                                <v-text-field
                                     :label="$t('user.password')"
                                     :placeholder="$t('user.placeholder.password')"
                                     name="password" type="password" v-model="password"
-                                ></text-input>
+                                ></v-text-field>
                                 <!--<v-select-->
                                 <!--:options="options"-->
                                 <!--label="Remember me for..."-->
                                 <!--v-model="remember"-->
                                 <!--&gt;</v-select>-->
                                 <v-btn class="aligned" flat="flat" dark="dark" success block type="submit"
+                                    @click.native="login"
                                     :loading="loading" :disabled="loading">
                                     <v-icon left>vpn_key</v-icon>
                                     {{$t('user.login.button')}}
@@ -61,13 +64,14 @@
                 username: "",
                 password: "",
                 remember: "",
-                test: false,
                 options: [
                     {"text": "5 minutes"},
                     {"text": "1 hour"},
                     {"text": "1 day"},
                     {"text": "7 days"},
-                ]
+                ],
+                authsuccess: false,
+                authfail: false
             }
         },
         computed: {
@@ -105,7 +109,7 @@
                 component.$children.forEach(child => {
                     noerrors = this.validate(child) && noerrors
                 })
-                return noerrors && !component.errors.any()
+                return noerrors && !component.verrors.any()
             },
             login() {
                 if(this.validate(this)) {
@@ -115,13 +119,11 @@
                         password: this.password
                     }).then((res) => {
                         if (res) {
-                            var auth = this.$t('auth.success');
-                            this.$vuetify.toast.create(auth, "right")
+                            this.authsuccess = true
                             this.$router.push('/'+this.$route.params.lg+'/service')
                             this.$store.dispatch('walletInfo')
                         } else {
-                            var auth = this.$t('auth.fail');
-                            this.$vuetify.toast.create(auth, "right")
+                            this.authfail = true
                         }
                         this.$store.commit('setLoaded')
                     })

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -84,9 +84,7 @@
             this.$store.commit('setToolbarTitle', 'header.login')
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
-                if (nosession) {
-                    //this.$vuetify.toast.create(this.$t('auth.no'), "right")
-                } else {
+                if (!nosession) {
                     this.$vuetify.toast.create(this.$t('auth.already'), "right")
                     this.$router.push('/'+this.$route.params.lg+'/service')
                 }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -85,7 +85,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (!nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.already'), "right")
+                    this.$store.commit('setAlreadyAuth')
                     this.$router.push('/'+this.$route.params.lg+'/service')
                 }
             })

--- a/src/views/Payments.vue
+++ b/src/views/Payments.vue
@@ -69,7 +69,7 @@ tr {cursor:default}
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.$store.commit('setLoading')

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -56,7 +56,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    //this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.loadProfile()

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -95,7 +95,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (!nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.already'), "right")
+                    this.$store.commit('setAlreadyAuth')
                     this.$router.push('/'+this.$route.params.lg+'/service')
                 }
             })

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -94,9 +94,7 @@
             this.$store.commit('setToolbarTitle', 'header.register')
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
-                if (nosession) {
-                    //this.$vuetify.toast.create(this.$t('auth.no'), "right")
-                } else {
+                if (!nosession) {
                     this.$vuetify.toast.create(this.$t('auth.already'), "right")
                     this.$router.push('/'+this.$route.params.lg+'/service')
                 }

--- a/src/views/Services.vue
+++ b/src/views/Services.vue
@@ -87,7 +87,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.$store.commit('setLoading')

--- a/src/views/Ticket.vue
+++ b/src/views/Ticket.vue
@@ -1,5 +1,8 @@
 <template>
     <div>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="duplicate">{{ $t('ticket.msg_duplicate') }}</v-snackbar>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="tooShort">{{ $t('ticket.msg_too_short') }}</v-snackbar>
+        <v-snackbar :timeout="2000" :top="true" :right="true" v-model="tooLong">{{ $t('ticket.msg_too_long') }}</v-snackbar>
         <v-container v-if="!loading">
             <v-row>
                 <v-col xl2></v-col>
@@ -129,7 +132,10 @@
     export default {
         data () {
             return {
-                msg: ''
+                msg: '',
+                duplicate: false,
+                tooShort: false,
+                tooLong: false
             }
         },
         mounted () {
@@ -196,7 +202,7 @@
                 if (messages.length > 0) {
                     var lastMsg = messages[messages.length - 1].message
                     if (msg == lastMsg) {
-                        this.$vuetify.toast.create(this.$t("ticket.msg_duplicate"), "right")
+                        this.duplicate = true
                         //show user that message was probably send earlier when some Internet connection errors occurred
                         this.loadMessages()
                         return false
@@ -205,13 +211,13 @@
 
                 //too short?
                 if (msg.length < 2) {
-                    this.$vuetify.toast.create(this.$t("ticket.msg_too_short"), "right")
+                    this.tooShort = true
                     return false
                 }
 
                 //too long?
                 if (msg.length > 3000) {
-                    this.$vuetify.toast.create(this.$t("ticket.msg_too_long"), "right")
+                    this.tooLong = true
                     return false
                 }
 

--- a/src/views/Ticket.vue
+++ b/src/views/Ticket.vue
@@ -138,7 +138,7 @@
             this.$store.commit('setTicketMessages', [])
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.loadTicket()

--- a/src/views/Tickets.vue
+++ b/src/views/Tickets.vue
@@ -85,7 +85,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.$store.commit('setLoading')

--- a/src/views/Vps.vue
+++ b/src/views/Vps.vue
@@ -302,7 +302,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.$store.commit('setLoading')

--- a/src/views/Vps.vue
+++ b/src/views/Vps.vue
@@ -188,12 +188,13 @@
                         <v-card-text>
                             <v-card-row>
                                 <i class="fa fa-fw fa-2x fa-pencil" style="padding-bottom: 1rem;"></i>
-                                <v-text-input
+                                <v-text-field
                                     v-model="newname"
+                                    style="margin-bottom: 0;"
                                     :label="$t('vps.name')"
                                     :placeholder="$t('vps.placeholder.name')">
                                     {{vps.name}}
-                                </v-text-input>
+                                </v-text-field>
                             </v-card-row>
                         </v-card-text>
                         <v-card-row actions style="justify-content: flex-start">

--- a/src/views/VpsIpDdos.vue
+++ b/src/views/VpsIpDdos.vue
@@ -62,7 +62,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), "right")
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.$store.commit('setLoading')

--- a/src/views/VpsIpSettings.vue
+++ b/src/views/VpsIpSettings.vue
@@ -87,20 +87,20 @@
                                 <h2 class="title">{{$t('vpsip.add.header')}}</h2>
                             </v-card-text>
                             <v-card-text>
-                                <text-input
+                                <v-text-field
                                     :validationmessage="$t('validation.port')" :validation="validatePortFrom"
                                     :label="$t('vpsip.add.portfrom.label')"
                                     :placeholder="$t('vpsip.add.portfrom.placeholder')"
                                     name="portfrom" type="number" v-model="portFrom"
-                                ></text-input>
-                                <text-input
+                                ></v-text-field>
+                                <v-text-field
                                     :validationmessage="$t('validation.port')" :validation="validatePortTo"
                                     :label="$t('vpsip.add.portto.label')"
                                     :placeholder="$t('vpsip.add.portto.placeholder')"
                                     name="portto" type="number" v-model="portTo"
-                                ></text-input>
+                                ></v-text-field>
                                 <v-select
-                                    :options="selectProtocols"
+                                    :items="selectProtocols"
                                     :label="$t('vpsip.add.protocol')"
                                     v-model="protocol"
                                 ></v-select>
@@ -126,9 +126,13 @@
     </div>
 </template>
 <style>
-select option[disabled] {
-    display: none;
-}
+    select option[disabled] {
+        display: none;
+    }
+
+    div.modal {
+        max-height: initial;
+    }
 </style>
 <script>
     export default {
@@ -139,9 +143,9 @@ select option[disabled] {
                 interval: null,
                 addModal: false,
                 addingRule: false,
-                portFrom: 0,
-                portTo: 0,
-                protocol: 'other',
+                portFrom: '',
+                portTo: '',
+                protocol: { value: 'other', text: 'Other' },
                 protocols: {
                     'arkSurvivalEvolved': 'ARK: Survival Evolved',
                     'arma': 'Arma',
@@ -261,10 +265,10 @@ select option[disabled] {
                 component.$children.forEach(child => {
                     noerrors = this.validate(child) && noerrors
                 })
-                return noerrors && !component.errors.any()
+                return noerrors && !component.verrors.any()
             },
             clearValidation(component) {
-                component.errors.clear()
+                component.verrors.clear()
                 component.$children.forEach(child => {
                     this.clearValidation(child)
                 })
@@ -290,7 +294,7 @@ select option[disabled] {
                     }
                     this.addingRule = true
                     this.$store.dispatch('vpsIpGameRuleAdd', Object.assign(this.$route.params,
-                        { protocol: this.protocol, port_from: portFrom, port_to: portTo })).then(() => {
+                        { protocol: this.protocol.value, port_from: portFrom, port_to: portTo })).then(() => {
                             this.addingRule = false
                             this.addModal = false
                             this.portFrom = ''

--- a/src/views/VpsIpSettings.vue
+++ b/src/views/VpsIpSettings.vue
@@ -170,7 +170,7 @@
             this.$emit('view', this.meta())
             this.$store.dispatch('checkSession').then((nosession) => {
                 if (nosession) {
-                    this.$vuetify.toast.create(this.$t('auth.no'), 'right')
+                    this.$store.commit('setNoAuth')
                     this.$router.push('/login')
                 } else {
                     this.$store.commit('setLoading')


### PR DESCRIPTION
Regressions:
- No placeholders in text fields.
- No validation - new Vuetify components introduce their own, worse validation system. We should try rewrite custom text-input component using Vuetify classes for showing error, but we should still use vee-validate for validation.

Features:
- Snackbars are propably better than toasts, because only one same message can be visible in one time - less spam.
- Better style of select component. 